### PR TITLE
Move baselines rule to number 2

### DIFF
--- a/content/04.baselines.md
+++ b/content/04.baselines.md
@@ -1,0 +1,1 @@
+## Rule 2: Use traditional methods to establish performance baselines

--- a/content/04.dl-complexities.md
+++ b/content/04.dl-complexities.md
@@ -1,1 +1,0 @@
-## Rule 2: Understand the complexities of training deep neural networks

--- a/content/05.dl-complexities.md
+++ b/content/05.dl-complexities.md
@@ -1,0 +1,1 @@
+## Rule 3: Understand the complexities of training deep neural networks

--- a/content/05.know-your-problem.md
+++ b/content/05.know-your-problem.md
@@ -1,1 +1,0 @@
-## Rule 3: Know your data and your question

--- a/content/06.architecture-and-representation.md
+++ b/content/06.architecture-and-representation.md
@@ -1,1 +1,0 @@
-## Rule 4: Choose an appropriate neural network architecture and data representation

--- a/content/06.know-your-problem.md
+++ b/content/06.know-your-problem.md
@@ -1,0 +1,1 @@
+## Rule 4: Know your data and your question

--- a/content/07.architecture-and-representation.md
+++ b/content/07.architecture-and-representation.md
@@ -1,0 +1,1 @@
+## Rule 5: Choose an appropriate neural network architecture and data representation

--- a/content/07.hyperparameters.md
+++ b/content/07.hyperparameters.md
@@ -1,1 +1,0 @@
-## Rule 5: Tune your hyperparameters extensively and systematically

--- a/content/08.hyperparameters.md
+++ b/content/08.hyperparameters.md
@@ -1,0 +1,1 @@
+## Rule 6: Tune your hyperparameters extensively and systematically

--- a/content/08.overfitting.md
+++ b/content/08.overfitting.md
@@ -1,1 +1,0 @@
-## Rule 6: Address deep neural networks' increased tendency to overfit the dataset

--- a/content/09.baselines.md
+++ b/content/09.baselines.md
@@ -1,1 +1,0 @@
-## Rule 7: Use traditional methods to establish performance baselines

--- a/content/09.overfitting.md
+++ b/content/09.overfitting.md
@@ -1,0 +1,1 @@
+## Rule 7: Address deep neural networks' increased tendency to overfit the dataset

--- a/rules.md
+++ b/rules.md
@@ -10,25 +10,25 @@
   - Test the robustness of your DL model in a simulation framework in which the ground truth is known ([#49](https://github.com/Benjamin-Lee/deep-rules/issues/49))
   - Sanity checks, good coding practices, design and run experiments systematically ([#52](https://github.com/Benjamin-Lee/deep-rules/issues/52), [#35](https://github.com/Benjamin-Lee/deep-rules/issues/35))
 
-2. Understand the complexities of training deep neural networks
+2. Use traditional methods to establish performance baselines ([#41](https://github.com/Benjamin-Lee/deep-rules/issues/41), [#11](https://github.com/Benjamin-Lee/deep-rules/issues/11), [#10](https://github.com/Benjamin-Lee/deep-rules/issues/10))
+
+3. Understand the complexities of training deep neural networks
   - Rerun multiple times different initial weight settings (e.g., avg. top 3 out of 5 performance) for fair comparison ([#42](https://github.com/Benjamin-Lee/deep-rules/issues/42))
   - More extensive model selection: architecture as well as hyperparameter search required ([#42](https://github.com/Benjamin-Lee/deep-rules/issues/42))
   - Deep learning really shines on unstructured, not structured data ([#22](https://github.com/Benjamin-Lee/deep-rules/issues/22))
 
-3. Know your data and your question
+4. Know your data and your question
   - ([#31](https://github.com/Benjamin-Lee/deep-rules/issues/31), [#12](https://github.com/Benjamin-Lee/deep-rules/issues/12), [#13](https://github.com/Benjamin-Lee/deep-rules/issues/13),  [#18](https://github.com/Benjamin-Lee/deep-rules/issues/18))
 
-4. Choose an appropriate neural network architecture and data representation ([#29](https://github.com/Benjamin-Lee/deep-rules/issues/29))
+5. Choose an appropriate neural network architecture and data representation ([#29](https://github.com/Benjamin-Lee/deep-rules/issues/29))
   - A bit of discussion on DL architectures and how they apply to different problems here would be helpful
 
-5. Tune your hyperparameters extensively and systematically ([#42](https://github.com/Benjamin-Lee/deep-rules/issues/42), [#11](https://github.com/Benjamin-Lee/deep-rules/issues/11))
+6. Tune your hyperparameters extensively and systematically ([#42](https://github.com/Benjamin-Lee/deep-rules/issues/42), [#11](https://github.com/Benjamin-Lee/deep-rules/issues/11))
   - Again, discussion on DL specific tuning would be helpful. i.e. layers, dropout, activation functions etc.
 
-6. Address deep neural networks' increased tendency to overfit the dataset ([#28](https://github.com/Benjamin-Lee/deep-rules/issues/28))
+7. Address deep neural networks' increased tendency to overfit the dataset ([#28](https://github.com/Benjamin-Lee/deep-rules/issues/28))
   - Some discussion on how not to overfit particularly in the context of DL methods.
   - Overfitting as a symptom of fitting to confounding effects ([#55](https://github.com/Benjamin-Lee/deep-rules/issues/55))
-
-7. Use traditional methods to establish performance baselines ([#41](https://github.com/Benjamin-Lee/deep-rules/issues/41), [#11](https://github.com/Benjamin-Lee/deep-rules/issues/11), [#10](https://github.com/Benjamin-Lee/deep-rules/issues/10))
 
 8. Do not necessarily consider a DL model as a black box
   - How to interpret DL models ([#36](https://github.com/Benjamin-Lee/deep-rules/issues/36))


### PR DESCRIPTION
This implements @sgfin's suggestion (https://github.com/Benjamin-Lee/deep-rules/issues/3#issuecomment-445432084).  I agree that this is an essential rule and should come early in the list.

If we plan to do more rule reshuffling, we could temporarily convert `Rule 1` etc. in the headers to `Rule X` to reduce the manual renumbering.  We could do the numbering with Jinja2, but that might be overkill.