### PR TITLE
Upgrade to latest manubot-rootstock on 2018-12-18

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,10 @@ output/*
 
 webpage/v
 
+# When PDF building fails, a temporary symlink named images in the root
+# directory is not removed.
+/images
+
 # Manubot cache directory
 ci/cache
 
@@ -17,3 +21,17 @@ __pycache__/
 # Misc temporary files
 *.bak
 
+# Operating system specific files
+
+## Linux
+*~
+.Trash-*
+
+## macOS
+.DS_Store
+._*
+.Trashes
+
+## Windows
+Thumbs.db
+[Dd]esktop.ini

--- a/USAGE.md
+++ b/USAGE.md
@@ -1,18 +1,18 @@
 # Manubot usage guidelines
 
-This repository uses the [Manubot](https://github.com/greenelab/manubot) to automatically produce a manuscript from its source.
+This repository uses [Manubot](https://github.com/greenelab/manubot-rootstock) to automatically produce a manuscript from the source in the [`content`](content) directory.
 
 ## Manubot markdown
 
 Manuscript text should be written in markdown files, which should be located in [`content`](content) with a digit prefix for ordering (e.g. `01.`, `02.`, etc.) and a `.md` extension.
 
-For basic formatting, check out the [CommonMark Help](http://commonmark.org/help/) page for an introduction to the formatting options provided by standard markdown.
-In addition, manubot supports an extended version of markdown, tailored for scholarly writing, which includes [Pandoc's Markdown](http://pandoc.org/MANUAL.html#pandocs-markdown) and the extensions discussed below.
+For basic formatting, check out the [CommonMark Help](https://commonmark.org/help/) page for an introduction to the formatting options provided by standard markdown.
+In addition, Manubot supports an extended version of markdown, tailored for scholarly writing, which includes [Pandoc's Markdown](https://pandoc.org/MANUAL.html#pandocs-markdown) and the extensions discussed below.
 
 Within a paragraph in markdown, single newlines are interpreted as whitespace (same as a space).
 A paragraph's source does not need to contain newlines.
 However, "one paragraph per line" makes the git diff less precise, leading to less granular review commenting, and makes conflicts more likely.
-Therefore, we recommend using [semantic linefeeds](http://rhodesmill.org/brandon/2012/one-sentence-per-line/ "Semantic Linefeeds. Brandon Rhodes. 2012") — newlines between sentences.
+Therefore, we recommend using [semantic linefeeds](https://rhodesmill.org/brandon/2012/one-sentence-per-line/ "Semantic Linefeeds. Brandon Rhodes. 2012") — newlines between sentences.
 We have found that "one sentence per line" is preferable to "word wrap" or "one paragraph per line".
 
 ### Tables
@@ -30,7 +30,7 @@ Table: Caption for this example table. {#tbl:example-id}
 
 Support for table numbering and citation is provided by [`pandoc-tablenos`](https://github.com/tomduck/pandoc-tablenos).
 Above, `{#tbl:example-id}` sets the table ID, which creates an HTML anchor and allows citing the table like `@tbl:example-id`.
-For easy creation of markdown tables, check out the [Tables Generator](http://www.tablesgenerator.com/markdown_tables) webapp.
+For easy creation of markdown tables, check out the [Tables Generator](https://www.tablesgenerator.com/markdown_tables) webapp.
 
 ### Figures
 
@@ -45,11 +45,11 @@ This figure can be cited in the text using `@fig:example-id`.
 In context, a figure citation may look like: `Figure {@fig:example-id}B shows …`.
 
 For images created by the manuscript authors that are hosted elsewhere on GitHub, we recommend using a [versioned](https://help.github.com/articles/getting-permanent-links-to-files/) GitHub URL to embed figures, thereby preserving exact image provenance.
-When embedding SVG images hosted on GitHub, passing the URL through [RawGit](https://rawgit.com/) is necessary.
-An example of a URL that has been passed through RawGit is:
+When embedding SVG images hosted on GitHub, it's necessary to append `?sanitize=true` to the `raw.githubusercontent.com` URL.
+For example:
 
 ```
-https://cdn.rawgit.com/greenelab/scihub/572d6947cb958e797d1a07fdb273157ad9154273/figure/citescore.svg
+https://raw.githubusercontent.com/greenelab/scihub/572d6947cb958e797d1a07fdb273157ad9154273/figure/citescore.svg?sanitize=true
 ```
 
 Figures placed in the [`content/images`](content/images) directory can be embedded using their relative path.
@@ -59,19 +59,19 @@ For example, we embed an [ORCID](https://orcid.org/) icon inline using:
 ![ORCID icon](images/orcid.svg){height="13px"}
 ```
 
-The bracketed text following the image declaration is interpreted by Pandoc's [`link_attributes`](http://pandoc.org/MANUAL.html#extension-link_attributes) extension.
+The bracketed text following the image declaration is interpreted by Pandoc's [`link_attributes`](https://pandoc.org/MANUAL.html#extension-link_attributes) extension.
 For example, the following will override the figure number to be "S1" and set the image width to 5 inches:
 
 ```md
 {#fig:supplement tag="S1" width="5in"}
 ```
 
-We recommend always specifying the width of SVG images (even if just `width="100%"`), since otherwise SVGs may not render properly in the [WeasyPrint](http://weasyprint.org/) PDF export.
+We recommend always specifying the width of SVG images (even if just `width="100%"`), since otherwise SVGs may not render properly in the [WeasyPrint](https://weasyprint.org/) PDF export.
 
 ### Citations
 
-Manubot supports Pandoc [citations](http://pandoc.org/MANUAL.html#citations) via `pandoc-citeproc`.
-However, Manubot performs automated citation processing and metadata retrieval on raw citations.
+Manubot supports Pandoc [citations](https://pandoc.org/MANUAL.html#citations) via `pandoc-citeproc`.
+However, Manubot performs automated citation processing and metadata retrieval on in-text citations.
 Therefore, citations must be of the following form: `@source:identifier`, where `source` is one of the options described below.
 When choosing which source to use for a citation, we recommend the following order:
 
@@ -79,12 +79,17 @@ When choosing which source to use for a citation, we recommend the following ord
 2. PubMed Central ID, cite like `@pmcid:PMC4497619`.
 3. PubMed ID, cite like `@pmid:26158728`.
 4. _arXiv_ ID, cite like `@arxiv:1508.06576v2`.
-5. URL / webpage, cite like `@url:http://openreview.net/pdf?id=Sk-oDY9ge`.
+5. ISBN (International Standard Book Number), cite like `@isbn:9781339919881`.
+6. URL / webpage, cite like `@url:https://nyti.ms/1QUgAt1`.
+7. Wikidata Items, cite like `@wikidata:Q50051684`.
+   Note that anyone can edit or add records on [Wikidata](https://www.wikidata.org), so users are encouraged to contribute metadata for hard-to-cite works to Wikidata as an alternative to using a `raw` citation.
+8. For references that do not have any of the persistent identifiers above, use a raw citation like `@raw:old-manuscript`.
+   Metadata for raw citations must be provided manually.
 
 Cite multiple items at once like:
 
 ```md
-Here is a sentence with several citations [@doi:10.15363/thinklab.4; @pmid:26158728; @arxiv:1508.06576].
+Here is a sentence with several citations [@doi:10.15363/thinklab.4; @pmid:26158728; @arxiv:1508.06576; @isbn:9780394603988].
 ```
 
 Note that multiple citations must be semicolon separated.
@@ -96,9 +101,9 @@ For example, the following citations all refer to the same study, but will be tr
 The system also supports citation tags, which are recommended for the following applications:
 
 1. A citation's identifier contains forbidden characters, such as `;` or `=`, or ends with a non-alphanumeric character other than `/`.
-  In these instances, you must use a tag.
+   In these instances, you must use a tag.
 2. A single reference is cited many times.
-  Therefore, it might make sense to define a tag, so if the citation updates (e.g. a newer version becomes available), only a single change is required.
+   Therefore, it might make sense to define a tag, so if the citation updates (e.g. a newer version becomes available), only a single change is required.
 
 Tags should be defined in [`content/citation-tags.tsv`](content/citation-tags.tsv).
 If `citation-tags.tsv` defines the tag `study-x`, then this study can be cited like `@tag:study-x`.
@@ -109,8 +114,8 @@ The Manubot workflow requires the bibliographic details for references (the set 
 The Manubot attempts to automatically retrieve metadata and generate valid citeproc JSON for references, which is exported to `output/references.json`.
 However, in some cases the Manubot fails to retrieve metadata or generates incorrect or incomplete citeproc metadata.
 Errors are most common for `url` references.
-For these references, you can manually specify the correct citeproc in [`content/manual-references.json`](content/manual-references.json), which will override the automatically generated reference data.
-To do so, create a new citeproc record that contains the field `"standard_citation"` with the appropriate reference identifier as its value.
+For these references, you can manually specify the correct CSL Data in [`content/manual-references.json`](content/manual-references.json), which will override the automatically generated reference data.
+To do so, create a new CSL JSON Item that contains the field `"standard_citation"` with the appropriate reference identifier as its value.
 The identifier can be obtained from the `standard_citation` column of `citations.tsv`, which is located in the `output` branch or in the `output` subdirectory of local builds.
 As an example, `manual-references.json` contains:
 
@@ -118,11 +123,23 @@ As an example, `manual-references.json` contains:
 "standard_citation": "url:https://github.com/greenelab/manubot-rootstock"
 ```
 
+The metadata for `raw` citations must be provided in `manual-references.json` or an error will occur.
+For example, to cite `@raw:private-message` in a manuscript, a corresponding CSL Item in `manual-references.json` is required, such as:
+
+```json
+{
+  "type": "personal_communication",
+  "standard_citation": "raw:private-message",
+  "title": "Personal communication with Doctor X"
+}
+```
+
+All references provided in `manual-references.json` must provide values for the `type` and `standard_citation` fields.
 For guidance on what CSL JSON should be like for different document types, refer to [these examples](https://github.com/aurimasv/zotero-import-export-formats/blob/a51c342e66bebd97b73a7230047b801c8f7bb690/CSL%20JSON.json).
 
 ## Manuscript metadata
 
-[`content/metadata.yaml`](content/metadata.yaml) contains manuscript metadata that gets passed through to Pandoc, via a [`yaml_metadata_block`](http://pandoc.org/MANUAL.html#extension-yaml_metadata_block).
+[`content/metadata.yaml`](content/metadata.yaml) contains manuscript metadata that gets passed through to Pandoc, via a [`yaml_metadata_block`](https://pandoc.org/MANUAL.html#extension-yaml_metadata_block).
 `metadata.yaml` should contain the manuscript `title`, `authors` list, `keywords`, and `lang` ([language tag](https://www.w3.org/International/articles/language-tags/ "W3C: Language tags in HTML and XML")).
 Additional metadata, such as `date`, will automatically be created by the Manubot.
 Manubot uses the [timezone](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones) specified in [`build.sh`](build/build.sh) for setting the manuscript's date.
@@ -156,9 +173,11 @@ For additional examples, check out existing manuscripts that use the Manubot (so
 
 + Satoshi Nakamoto's Bitcoin Whitepaper ([source](https://github.com/dhimmel/bitcoin-whitepaper/), [manuscript](https://dhimmel.github.io/bitcoin-whitepaper/), [commentary](https://steemit.com/manubot/@dhimmel/how-i-used-the-manubot-to-reproduce-the-bitcoin-whitepaper))
 + The Sci-Hub Coverage Study ([source](https://github.com/greenelab/scihub-manuscript), [manuscript](https://greenelab.github.io/scihub-manuscript/))
++ The GimmeMotifs manscript on transcription factor motif analysis ([source](https://github.com/simonvh/gimmemotifs-manuscript), [manuscript](https://simonvh.github.io/gimmemotifs-manuscript/manuscript.pdf))
 + A Report for the Vagelos Scholars Program by Michael Zietz ([source](https://github.com/zietzm/Vagelos2017), [manuscript](https://zietzm.github.io/Vagelos2017/))
 + The Deep Review ([source](https://github.com/greenelab/deep-review), [manuscript](https://greenelab.github.io/deep-review/))
 + The Meta Review ([source](https://github.com/greenelab/meta-review), [manuscript](https://greenelab.github.io/meta-review/))
++ A review of Network Methods for Multiomic Data Integration ([source](https://github.com/zietzm/integration-review), [manuscript](https://zietzm.github.io/integration-review/))
 + The Project Rephetio Manuscript ([source](https://github.com/dhimmel/rephetio-manuscript/), [manuscript](https://dhimmel.github.io/rephetio-manuscript/))
 + A Literature Review for Project Planning by David Slochower ([source](https://github.com/slochower/synthetic-motor-literature), [manuscript](https://slochower.github.io/synthetic-motor-literature/))
 + The TFSEE Manuscript by Venkat Malladi et al. ([source](https://github.com/vsmalladi/tfsee-manuscript), [manuscript](https://vsmalladi.github.io/tfsee-manuscript/))

--- a/build/README.md
+++ b/build/README.md
@@ -2,15 +2,20 @@
 
 [`build.sh`](build.sh) builds the repository.
 `sh build/build.sh` should be executed from the root directory of the repository.
+By default, `build.sh` creates HTML and PDF outputs.
+However, setting the `BUILD_PDF` environment variable to `false` will suppress PDF output.
+For example, run local builds using the command `BUILD_PDF=false sh build/build.sh`.
 
 To build a DOCX file of the manuscript, set the `BUILD_DOCX` environment variable to `true`.
 For example, use the command `BUILD_DOCX=true sh build/build.sh`.
-Set a [Travis environment variable](https://docs.travis-ci.com/user/environment-variables/#Defining-Variables-in-Repository-Settings) to export DOCX for all Travis builds.
+To export DOCX for all Travis builds, set a [Travis environment variable](https://docs.travis-ci.com/user/environment-variables/#Defining-Variables-in-Repository-Settings).
 Currently, equation numbers via `pandoc-eqnos` are not supported for DOCX output.
 There is varying support for embedding images in DOCX output.
 Please reference [Pull Request #40](https://github.com/greenelab/manubot-rootstock/pull/40) for possible solutions and continued discussion.
 
 ## Environment
+
+Note: currently, **Windows is not supported**.
 
 Install or update the [conda](https://conda.io) environment specified in [`environment.yml`](environment.yml) by running:
 
@@ -23,4 +28,5 @@ conda env create --file environment.yml
 ```
 
 Activate with `conda activate manubot` (assumes `conda` version of [at least](https://github.com/conda/conda/blob/9d759d8edeb86569c25f6eb82053f09581013a2a/CHANGELOG.md#440-2017-12-20) 4.4).
-The environment should successfully install on both Linux and macOS (and possibly Windows).
+The environment should successfully install on both Linux and macOS.
+However, it will fail on Windows due to the [`pango`](https://anaconda.org/conda-forge/pango) dependency.

--- a/build/build.sh
+++ b/build/build.sh
@@ -42,31 +42,33 @@ pandoc --verbose \
   --output=output/manuscript.html \
   $INPUT_PATH
 
-# Create PDF output
-echo "Exporting PDF manuscript"
-ln -s content/images images
-pandoc \
-  --from=markdown \
-  --to=html5 \
-  --pdf-engine=weasyprint \
-  --pdf-engine-opt=--presentational-hints \
-  --filter=pandoc-fignos \
-  --filter=pandoc-eqnos \
-  --filter=pandoc-tablenos \
-  --bibliography=$BIBLIOGRAPHY_PATH \
-  --csl=$CSL_PATH \
-  --metadata link-citations=true \
-  --webtex=https://latex.codecogs.com/svg.latex? \
-  --css=webpage/github-pandoc.css \
-  --output=output/manuscript.pdf \
-  $INPUT_PATH
-rm -r images
+# Create PDF output (unless BUILD_PDF environment variable equals "false")
+if [ "$BUILD_PDF" != "false" ]; then
+  echo "Exporting PDF manuscript"
+  if [ -L images ]; then rm images; fi  # if images is a symlink, remove it
+  ln -s content/images
+  pandoc \
+    --from=markdown \
+    --to=html5 \
+    --pdf-engine=weasyprint \
+    --pdf-engine-opt=--presentational-hints \
+    --filter=pandoc-fignos \
+    --filter=pandoc-eqnos \
+    --filter=pandoc-tablenos \
+    --bibliography=$BIBLIOGRAPHY_PATH \
+    --csl=$CSL_PATH \
+    --metadata link-citations=true \
+    --webtex=https://latex.codecogs.com/svg.latex? \
+    --css=webpage/github-pandoc.css \
+    --output=output/manuscript.pdf \
+    $INPUT_PATH
+  rm images
+fi
 
-# Create DOCX output when user specifies to do so
-if [ "$BUILD_DOCX" = "true" ];
-then
-    echo "Exporting Word Docx manuscript"
-    pandoc --verbose \
+# Create DOCX output (if BUILD_DOCX environment variable equals "true")
+if [ "$BUILD_DOCX" = "true" ]; then
+  echo "Exporting Word Docx manuscript"
+  pandoc --verbose \
     --from=markdown \
     --to=docx \
     --filter=pandoc-fignos \

--- a/build/environment.yml
+++ b/build/environment.yml
@@ -9,22 +9,23 @@ dependencies:
   - conda-forge::jsonschema=2.6.0
   - conda-forge::pandas=0.23.4
   - conda-forge::pandoc=2.3.1
+  - conda-forge::pango=1.40.14
   - conda-forge::python=3.6.5
   - conda-forge::pyyaml=3.13
-  - conda-forge::requests=2.19.1
+  - conda-forge::requests=2.20.1
   - conda-forge::watchdog=0.8.3
   - pip:
     - errorhandler==2.0.1
-    - git+https://github.com/greenelab/manubot@9d97ec347882bcd85ab6aee7a3b4734105ebfc15
+    - git+https://github.com/greenelab/manubot@dae57036de250ca1ece852a4f5b3d7f946c25d50
     - jsonref==0.2
     - opentimestamps-client==0.6.0
-    - opentimestamps==0.4.0
+    - opentimestamps==0.3.0
     - pandoc-eqnos==1.3.0
     - pandoc-fignos==1.3.0
     - pandoc-tablenos==1.3.0
     - pandoc-xnos==1.1.1
     - pybase62==0.4.0
     - pysha3==1.0.2
-    - python-bitcoinlib==0.10.1
+    - python-bitcoinlib==0.9.0
     - requests-cache==0.4.13
     - weasyprint==0.42.3

--- a/build/webpage.py
+++ b/build/webpage.py
@@ -18,7 +18,21 @@ def parse_arguments():
     parser.add_argument(
         '--version',
         default=os.environ.get('TRAVIS_COMMIT', 'local'),
-        help="Used to create webpage/v/{version} directory. Generally a commit hash, tag, or 'local'",
+        help="Used to create webpage/v/{version} directory. "
+             "Generally a commit hash, tag, or 'local'. "
+             "(default: '%(default)s')"
+    )
+    cache_group = parser.add_mutually_exclusive_group()
+    cache_group.add_argument(
+        '--no-ots-cache',
+        action='store_true',
+        help="disable the timestamp cache."
+    )
+    cache_group.add_argument(
+        '--ots-cache',
+        default=pathlib.Path('ci/cache/ots'),
+        type=pathlib.Path,
+        help="location for the timestamp cache (default: %(default)s)."
     )
     args = parser.parse_args()
     return args
@@ -117,8 +131,11 @@ def create_version(args):
         'manuscript.pdf': 'manuscript.pdf',
     }
     for src, dst in renamer.items():
+        src_path = args.output_directory.joinpath(src)
+        if not src_path.exists():
+            continue
         shutil.copy2(
-            src=args.output_directory.joinpath(src),
+            src=src_path,
             dst=args.version_directory.joinpath(dst),
         )
 
@@ -135,7 +152,7 @@ def create_version(args):
     args.freeze_directory.joinpath('index.html').write_text(redirect_html)
 
 
-def get_versions():
+def get_versions(args):
     """
     Extract versions from the webpage/v directory, which should each contain
     a manuscript.
@@ -146,10 +163,53 @@ def get_versions():
     return versions
 
 
+def ots_upgrade(args):
+    """
+    Upgrade OpenTimestamps .ots files in versioned commit directory trees.
+
+    Upgrades each .ots file with a separate ots upgrade subprocess call due to
+    https://github.com/opentimestamps/opentimestamps-client/issues/71
+    """
+    ots_paths = list()
+    for version in get_versions(args):
+        ots_paths.extend(args.versions_directory.joinpath(version).glob('**/*.ots'))
+    ots_paths.sort()
+    for ots_path in ots_paths:
+        process_args = ['ots']
+        if args.no_ots_cache:
+            process_args.append('--no-cache')
+        else:
+            process_args.extend(['--cache', str(args.ots_cache)])
+        process_args.extend([
+            'upgrade',
+            str(ots_path),
+        ])
+        process = subprocess.run(
+            process_args,
+            stderr=subprocess.PIPE,
+            universal_newlines=True,
+        )
+        if process.returncode != 0:
+            print(f"OpenTimestamp upgrade command returned nonzero code ({process.returncode}).")
+        if not process.stderr.strip() == 'Success! Timestamp complete':
+            print(
+                f">>> {' '.join(map(str, process.args))}\n"
+                f"{process.stderr}"
+            )
+        backup_path = ots_path.with_suffix('.ots.bak')
+        if backup_path.exists():
+            if process.returncode == 0:
+                backup_path.unlink()
+            else:
+                # Restore original timestamp if failure
+                backup_path.rename(ots_path)
+
+
 if __name__ == '__main__':
     args = parse_arguments()
     configure_directories(args)
     print(args)
     create_version(args)
-    versions = get_versions()
+    versions = get_versions(args)
     print(versions)
+    ots_upgrade(args)

--- a/ci/deploy.sh
+++ b/ci/deploy.sh
@@ -31,13 +31,15 @@ git fetch origin gh-pages:gh-pages output:output
 
 # Configure versioned webpage
 python build/webpage.py \
+  --no-ots-cache \
   --checkout=gh-pages \
   --version=$TRAVIS_COMMIT
 
 # Generate OpenTimestamps
-ots stamp \
-  webpage/v/$TRAVIS_COMMIT/index.html \
-  webpage/v/$TRAVIS_COMMIT/manuscript.pdf
+ots stamp webpage/v/$TRAVIS_COMMIT/index.html
+if [ "$BUILD_PDF" != "false" ]; then
+  ots stamp webpage/v/$TRAVIS_COMMIT/manuscript.pdf
+fi
 
 # Commit message
 MESSAGE="\

--- a/webpage/README.md
+++ b/webpage/README.md
@@ -20,14 +20,18 @@ In general, a version is identified by the commit hash of the source content tha
 The `*.ots` files in version directories are OpenTimestamps which can be used to verify manuscript existence at or before a given time.
 [OpenTimestamps](https://opentimestamps.org/) uses the Bitcoin blockchain to attest to file hash existence.
 The `deploy.sh` script run during continuous deployment creates the `.ots` files.
-However, these files are initially dependent on calendar services and must be upgraded at a later time by running the following in the `gh-pages` branch:
+There is a delay before timestamps get confirmed by a Bitcoin block.
+Therefore, `.ots` files are initially incomplete and should be upgraded at a later time, so that they no longer rely on the availability of a calendar server to verify.
+`webpage.py`, which is run during continuous deployment, identifies files matched by `webpage/v/**/*.ots` and attempts to upgrade them.
+You can also manually upgrade timestamps, by running the following in the `gh-pages` branch:
 
 ```sh
-# Requires a local bitcoin node with JSON-RPC configured
 ots upgrade v/*/*.ots
 rm v/*/*.ots.bak
 git add v/*/*.ots
 ```
+
+Verifying timestamps with the `ots verify` command requires running a local bitcoin node with JSON-RPC configured, at this time.
 
 ## Source
 


### PR DESCRIPTION
**Did you add yourself as a [contributor](https://github.com/Benjamin-Lee/deep-rules/blob/master/contributors.md) if this is your first contribution?**

<!-- Put an x in between the brackets to show you did! -->
- [x] Yes, I added myself or am already a contributor

**Any more details?**
This updates manubot and manubot-rootstock per the [setup instructions](https://github.com/greenelab/manubot-rootstock/blob/master/SETUP.md#merging-upstream-manubot-rootstock-changes).  See the manubot [release notes](https://github.com/greenelab/manubot/releases) for a detailed description of the new features.  The most important for this project will be better support for PMCID and URL references and well as ISBN and Wikidata references.

I will merge once this is approved.  We need to make sure to "Create a merge commit" instead of merging in the two other ways (squash or rebase).