### PR TITLE
Add references for biased generalization performance estimates

### DIFF
--- a/content/03.ml-concepts.md
+++ b/content/03.ml-concepts.md
@@ -4,7 +4,7 @@ DL has proven to be an extremely powerful paradigm capable of outperforming “t
 Many best practices for machine learning also apply to deep learning.
 For instance, deep supervised learning models should be trained, tuned, and tested on non-overlapping datasets.
 Similarly, to prevent overfitting, the data used for testing should be locked and only used one-time for evaluating the final model after all tuning steps were completed. 
-Using a test set more than once will lead to biased estimates of the generalization performance  [@arXiv:1811.12808; @doi:10.1162/089976698300017197].
+Using a test set more than once will lead to biased estimates of the generalization performance  [@arxiv:1811.12808; @doi:10.1162/089976698300017197].
 Those developing deep learning models should also select data that are relevant to the problem at hand; non-salient data can hamper performance or lead to spurious conclusions.
 Furthermore, investigators should begin by thoroughly inspecting their data.
 When coupled with imprudence, data that is biased, skewed, or of low quality will produce models of dubious performance and limited generalizability.

--- a/content/03.ml-concepts.md
+++ b/content/03.ml-concepts.md
@@ -4,7 +4,7 @@ DL has proven to be an extremely powerful paradigm capable of outperforming “t
 Many best practices for machine learning also apply to deep learning.
 For instance, deep supervised learning models should be trained, tuned, and tested on non-overlapping datasets.
 Similarly, to prevent overfitting, the data used for testing should be locked and only used one-time for evaluating the final model after all tuning steps were completed. 
-Using a test set more than once will lead to biased estimates of the generalization performance.
+Using a test set more than once will lead to biased estimates of the generalization performance  [@arXiv:1811.12808; @doi:10.1162/089976698300017197].
 Those developing deep learning models should also select data that are relevant to the problem at hand; non-salient data can hamper performance or lead to spurious conclusions.
 Furthermore, investigators should begin by thoroughly inspecting their data.
 When coupled with imprudence, data that is biased, skewed, or of low quality will produce models of dubious performance and limited generalizability.


### PR DESCRIPTION
**Did you add yourself as a [contributor](https://github.com/Benjamin-Lee/deep-rules/blob/master/contributors.md) if this is your first contribution?**

<!-- Put an x in between the brackets to show you did! -->
- [x] Yes, I added myself or am already a contributor

Adds references for biasing the generalization performance estimates when re-using the test set, as discussed in the PR #142  review https://github.com/Benjamin-Lee/deep-rules/pull/142/files/bc4b4b6a73d9513fe8b248f1547abb1c9f59dbee..ac1b71ff4aeb46b2c2357b03715541eb02815d4d