### PR TITLE
Remove mention of VAE architecture as a hyperparameter

### DIFF
--- a/content/08.hyperparameters.md
+++ b/content/08.hyperparameters.md
@@ -6,11 +6,6 @@ The flexibility of neural networks to approximate arbitrary, continuous function
 You should expect to systematically evaluate the impact of numerous hyperparameters when you aim to apply deep neural networks to new data or challenges.
 Hyperparameters are typically manifested in the choice of optimization algorithms, learning rate, activation functions, number of hidden layers and hidden units, size of the training batches, weight initialization schemes, and also seeds for pseudo-random number generators used for dataset shuffling and weight initialization.
 Moreover, additional hyperparameters are introduced common techniques that facilitate the training of deeper architectures, such as norm penalties (typically in the form of $L^2$ regularization), Dropout [@tag:srivastava-dropout], and Batch Normalization [@tag:ioffe-batchnorm], which can reduce the effect of the so-called vanishing or exploding gradient problem when working with deep neural networks.
-Neural network architectures also have their odd nuances that affect hyperparameter portability.
-For example, in variational autoencoders (VAEs), two components are being optimized, a reconstruction and a distribution loss [@arxiv:1312.6114].
-In conventional implementations, the relative weighting of each component is a function of the number of input features (more increase the importance of reconstruction loss) and the number of features in the latent space (more increase the importance of the distribution loss).
-**{SR: I am not sure this is correct, why would a larger number of, e.g., pixels make the reconstruction loss more important? I suppose this is true if we just sum over the pixel-wise differences, but if we average, e.g., using MSE, I am not convinced this is true. Please comment.}**
-Users who apply a VAE architecture to a new dataset with more input features, even without changing any hyperparameters, alter the relative weights of the components of the loss function.
 
 This flexibility also makes it difficult to evaluate the extent to which neural network methods are well suited to solving a task.
 We discussed how the Continental Breakfast Included effect could affect methods developers seeking to compare techniques in [Tip 2](#baselines).


### PR DESCRIPTION
I'm working on getting the manuscript ready for submission. We've resolved almost all of the issues within the text except for this one. I propose removing the section altogether. Although architecture tuning is a good idea, I'm not sure that the VAE example is right. I think we're best off to remove it.