### PR TITLE
Fix DOI references

### DIFF
--- a/content/03.when-to-use-dl.md
+++ b/content/03.when-to-use-dl.md
@@ -1,7 +1,7 @@
 ## Tip 1: Decide whether deep learning is appropriate for your problem {#appropriate}
 
 In recent years, the number of projects and publications implementing deep learning in biology has risen tremendously [@doi:10.1089/omi.2018.0097; @doi:10.1007/978-981-15-3383-9_54; @doi:10.3390/info11040193]. Given deep learning's usefulness across a range of scientific questions and data modalities, it may seem as though it is a panacea for nearly all modeling problems.
-Neural networks that underpin deep learning models are, in fact, universal function approximators and are therefore theoretically capable of learning the functions that relate almost any input and output variables [@doi:10.1007/BF02551274; @tag:hornik-approximation]. However, deep learning is not suited to every modeling situation.
+Neural networks that underpin deep learning models are, in fact, universal function approximators and are therefore theoretically capable of learning the functions that relate almost any input and output variables [@doi:10.1007/BF02551274; @doi:10/dzwxkd]. However, deep learning is not suited to every modeling situation.
 The primary limiting factors for deep learning's suitability for a given problem is primarily limited by the training demands of neural network models, which require significant amounts of data, computing power, and programming as well as modeling expertise.
 
 In the areas of biology where data collection is thoroughly automated, such as DNA sequencing, large amounts of high-quality data may be available.

--- a/content/08.hyperparameters.md
+++ b/content/08.hyperparameters.md
@@ -1,6 +1,6 @@
 ## Tip 6: Tune your hyperparameters extensively and systematically {#hyperparameters}
 
-Given at least one hidden layer, a non-linear activation function, and a large number of hidden units, multi-layer neural networks can approximate arbitrary continuous functions that relate input and output variables [@doi:10.1016/0893-6080(91)90009-t; @doi:10.1016/S0893-6080(05)80131-5]. 
+Given at least one hidden layer, a non-linear activation function, and a large number of hidden units, multi-layer neural networks can approximate arbitrary continuous functions that relate input and output variables [@doi:10/dzwxkd; @doi:10/bjjdg2]. 
 Deeper architectures that feature additional hidden layers and an increasing number of overall hidden units and learnable weight parameters (the so-called increasing "capacity" of neural networks) allow for solving increasingly complex problems.
 However, this increased capacity results in many more parameters to fit and hyperparameters to tune, which can pose additional challenges during model training.
 In general, one should expect to systematically evaluate the impact of numerous hyperparameters when applying deep neural networks to new data or challenges.

--- a/content/10.blackbox.md
+++ b/content/10.blackbox.md
@@ -1,7 +1,7 @@
 ## Tip 8: Deep learning models can be made more transparent {#blackbox}
 
 While model interpretability is a broad concept, in much of the machine learning literature (including in our guidelines), it refers to the ability to identify the discriminative features that influence or sway the predictions.
-In certain cases, the goal behind interpretation is to understand the underlying data generating processes and biological mechanisms [@doi:org/10.3390/biom10030454].
+In certain cases, the goal behind interpretation is to understand the underlying data generating processes and biological mechanisms [@doi:10.3390/biom10030454].
 In other cases, the goal is to understand why a model made the prediction that it did for a specific example or set of examples.
 Machine learning models vary widely in terms of interpretability: some are fully transparent while others are considered "black-boxes" that make predictions with little ability to examine why.
 Logistic regression and decision tree models are generally considered interpretable [@doi:10.1007/978-1-4939-7756-7_16].

--- a/content/99.citation-tags.md
+++ b/content/99.citation-tags.md
@@ -1,7 +1,6 @@
 [@tag:srivastava-dropout]: http://dl.acm.org/citation.cfm?id=2670313
 [@tag:ioffe-batchnorm]: https://dl.acm.org/citation.cfm?id=3045118.3045167
 [@tag:garson-interpreting]: https://dl.acm.org/citation.cfm?id=129452
-[@tag:hornik-approximation]: doi:10.1016/0893-6080(91)90009-T
 [@tag:krogh-weight-decay]: http://dl.acm.org/citation.cfm?id=2986916.2987033
 [@tag:predicting-pneumonia-mortality]: doi:10.1016/S0933-3657(96)00367-3
 [@tag:Yosinski2014]: https://papers.nips.cc/paper/5347-how-transferable-are-features-in-deep-neural-networks


### PR DESCRIPTION
**Did you add yourself as a [contributor](https://github.com/Benjamin-Lee/deep-rules/blob/master/contributors.md) if this is your first contribution?**

<!-- Put an x in between the brackets to show you did! -->
- [x] Yes, I added myself or am already a contributor

**Any more details?**
Follow up to #294.  The HTML version on GitHub Pages is having problems with these references.  I'm getting rid of the `hornik-approximation` tag everywhere else so that there isn't confusion about whether to use the tag or short DOI.