### PR TITLE
Add sequence conversion strategies and CGR

### DIFF
--- a/content/07.architecture-and-representation.md
+++ b/content/07.architecture-and-representation.md
@@ -14,7 +14,9 @@ They are able to learn complex non-linear relationships across the input data de
 Similarly, if the dataset is comprised of images, convolutional neural networks (CNNs) are a good choice because they emphasize local structures and adjacency within the data.
 CNNs may also be a good choice for learning on sequences.
 Recent empirical evidence suggests that they can outperform canonical sequence learning techniques such as recurrent neural networks and the closely related long short-term memory networks in some cases [@arxiv:1803.01271].
-Transformers are powerful sequence models [@arxiv:1706.03762] but require extensive data and computing power to train from scratch.
+Moreover, sequence conversion strategies can further increase the performance of CNNs on sequence data [@doi.org/10.1186/s13040-019-0196-x].
+For instance, especially chaos game representations (CGRs) [@doi.org/10.1093/bioinformatics/btz493] have recently been shown to be a promising conversion strategy.
+Transformers are also powerful sequence models [@arxiv:1706.03762] but require extensive data and computing power to train from scratch.
 Accessible high-level overviews of different neural network architectures are provided in [@doi:10.1016/j.ymeth.2020.06.016] and [@doi:10.1038/nature14539].
 
 Deep learning models typically benefit from increasing the amount of labeled training data.


### PR DESCRIPTION
Hello, I just humbled over this repository and this wonderful idea of a community article on Deep Learning in biology. 
I read the manuscript and added a sentence on sequence conversion strategies to `Tip 5` and also mentioned/proposed chaos game representations (CGRs) as a promising example thereof.

I think sequence conversion strategies are a very important aspect regarding Deep Learning, as this can have tremendous effects on the overall performance - as already stated in this section.

I hope this is useful and appropriate from the point of view of all existing contributors.

Best regards!

PS: I haven't added myself as a contributor as I'd like to suggest this PR and see if this might be of interest in advance.

**Did you add yourself as a [contributor](https://github.com/Benjamin-Lee/deep-rules/blob/master/contributors.md) if this is your first contribution?**

<!-- Put an x in between the brackets to show you did! -->
- [ ] Yes, I added myself or am already a contributor

**Any more details?**
