### PR TITLE
Build DOCX manuscript for journal submission

### DIFF
--- a/.github/workflows/manubot.yaml
+++ b/.github/workflows/manubot.yaml
@@ -13,6 +13,7 @@ jobs:
     env:
       GITHUB_PULL_REQUEST_SHA: ${{ github.event.pull_request.head.sha }}
       SPELLCHECK: true
+      BUILD_DOCX: true
     steps:
       - name: Set Environment Variables
         run: |


### PR DESCRIPTION
We may need a DOCX version of the manuscript for the journal submission.  This will have GitHub Actions export a DOCX with every build.